### PR TITLE
Removed jacoco.version property used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${jacoco.version}</version>
             <executions>
               <execution>
                 <id>prepare-agent</id>


### PR DESCRIPTION
The version is managed in the root pom, but that doesn't help much if you overwrite it with a non-existing property (which I removed in last commit)...